### PR TITLE
Key remapping plugin compatibility & focus check

### DIFF
--- a/src/main/java/com/camerapoints/CameraPointsConfig.java
+++ b/src/main/java/com/camerapoints/CameraPointsConfig.java
@@ -5,16 +5,24 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("camerapoints")
-public interface CameraPointsConfig extends Config
-{
+public interface CameraPointsConfig extends Config {
     @ConfigItem(
             position = 0,
             keyName = "preview",
             name = "Preview on hover",
             description = "Enables/Disables the camera preview on hovering the name of the Camera Point"
     )
-    default boolean showPreview()
-    {
+    default boolean showPreview() {
         return true;
+    }
+
+    @ConfigItem(
+            position = 1,
+            keyName = "keyRemap",
+            name = "Key remapping plugin enabled",
+            description = "When enabled, will not change camera while typing."
+    )
+    default boolean keyRemap() {
+        return false;
     }
 }

--- a/src/main/java/com/camerapoints/CameraPointsConfig.java
+++ b/src/main/java/com/camerapoints/CameraPointsConfig.java
@@ -5,14 +5,16 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("camerapoints")
-public interface CameraPointsConfig extends Config {
+public interface CameraPointsConfig extends Config
+{
     @ConfigItem(
             position = 0,
             keyName = "preview",
             name = "Preview on hover",
             description = "Enables/Disables the camera preview on hovering the name of the Camera Point"
     )
-    default boolean showPreview() {
+    default boolean showPreview()
+    {
         return true;
     }
 

--- a/src/main/java/com/camerapoints/CameraPointsPlugin.java
+++ b/src/main/java/com/camerapoints/CameraPointsPlugin.java
@@ -27,6 +27,7 @@ import com.camerapoints.utility.CameraPoint;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
+
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
 import java.time.Instant;
@@ -213,7 +214,8 @@ public class CameraPointsPlugin extends Plugin implements KeyListener
     public void keyTyped(KeyEvent e) { }
 
     @Override
-    public void keyPressed(KeyEvent e) {
+    public void keyPressed(KeyEvent e)
+    {
         if (!chatboxFocused()) {
             return;
         }

--- a/src/main/java/com/camerapoints/CameraPointsPlugin.java
+++ b/src/main/java/com/camerapoints/CameraPointsPlugin.java
@@ -193,9 +193,9 @@ public class CameraPointsPlugin extends Plugin implements KeyListener
     {
         // Most chat dialogs with numerical input are added without the chatbox or its key listener being removed,
         // so chatboxFocused() is true. The chatbox onkey script uses the following logic to ignore key presses,
-        // so we will use it too to not remap F-keys.
+        // so we will use it too to not set the camera.
         return isHidden(WidgetInfo.CHATBOX_MESSAGES) || isHidden(WidgetInfo.CHATBOX_TRANSPARENT_LINES)
-                // We want to block F-key remapping in the bank pin interface too, so it does not interfere with the
+                // We want to block camera setting in the bank pin interface too, so it does not interfere with the
                 // Keyboard Bankpin feature of the Bank plugin
                 || !isHidden(WidgetInfo.BANK_PIN_CONTAINER);
     }
@@ -244,8 +244,6 @@ public class CameraPointsPlugin extends Plugin implements KeyListener
             switch (e.getKeyCode()) {
                 case KeyEvent.VK_ESCAPE:
                 case KeyEvent.VK_ENTER:
-                    // When exiting typing mode, block the escape key
-                    // so that it doesn't trigger the in-game hotkeys
                     setTyping(false);
                     break;
                 case KeyEvent.VK_BACK_SPACE:
@@ -257,6 +255,7 @@ public class CameraPointsPlugin extends Plugin implements KeyListener
             }
         }
     }
+
     @Override
     public void keyReleased(KeyEvent e) { }
 }


### PR DESCRIPTION
I recycled some code from the Key Remapping plugin to do two things:

1) Check for the chatbox listener before setting the camera. For example, when typing in the World Map search box, the listener will be inactive and the plugin will no longer set the camera.

2) Add a "Key Remapping plugin enabled" setting. When checked, the plugin will not set the camera while typing in the chatbox. When unchecked, the plugin works as before except with the change 1).

I'm not sure if there's a way to directly check if a plugin is enabled, but if so that would be better than adding a toggle.