### PR TITLE
Move side panel button lower

### DIFF
--- a/src/main/java/com/camerapoints/CameraPointsPlugin.java
+++ b/src/main/java/com/camerapoints/CameraPointsPlugin.java
@@ -91,6 +91,7 @@ public class CameraPointsPlugin extends Plugin implements KeyListener
         navigationButton = NavigationButton.builder()
                 .tooltip("Camera Points")
                 .icon(ImageUtil.loadImageResource(getClass(), "panel_icon.png"))
+                .priority(1)
                 .panel(pluginPanel)
                 .build();
 


### PR DESCRIPTION
A few people have complained about the Camera Points being above the Configuration button used to manage all plugins. Ideally Configuration should be the highest button on the side panel.